### PR TITLE
Fixed link to LN specs

### DIFF
--- a/bitcoin.html
+++ b/bitcoin.html
@@ -521,7 +521,7 @@
           <h3>The Lightning Network:</h3>
           <ul>
             <li><a href="https://letstalkbitcoin.com/blog/post/the-lightning-network-elidhdicacs" target="_blank">Explained in Layman's Terms</a></li>
-            <li><a href="http://lightning.network/" target="_blank">Technical Specifications</a></li>
+            <li><a href="https://github.com/lightningnetwork/lightning-rfc" target="_blank">Technical Specifications (BOLTs)</a></li>
             <li><a href="https://medium.com/@AudunGulbrands1/lightning-faq-67bd2b957d70" target="_blank">Lightning Network FAQ</a></li>
             <li><a href="https://medium.com/lightning-resources" target="_blank">Lightning Resources</a></li>
             <li><a href="http://dev.lightning.community/">Lightning Network Developer site</a></li>


### PR DESCRIPTION
The website http://lightning.network only has a link to the whitepaper, and it is outdated. The actual work on the standard has been happening on [this github](https://github.com/lightningnetwork/lightning-rfc) for the past year.