### PR TITLE
Add CryptoAud.Io to the Bitcoin Page

### DIFF
--- a/bitcoin.html
+++ b/bitcoin.html
@@ -259,6 +259,7 @@
             <li><a href="http://www.coindesk.com/" target="_blank">Coindesk</a></li>
             <li><a href="http://coinjournal.net/" target="_blank">CoinJournal</a></li>
             <li><a href="http://cointelegraph.com/" target="_blank">CoinTelegraph</a></li>
+            <li><a href="http://cointelegraph.com/" target="_blank">CryptoAud.Io</a></li>
           </ul>
           <br>
           <h3>Podcasts:</h3>

--- a/bitcoin.html
+++ b/bitcoin.html
@@ -259,7 +259,7 @@
             <li><a href="http://www.coindesk.com/" target="_blank">Coindesk</a></li>
             <li><a href="http://coinjournal.net/" target="_blank">CoinJournal</a></li>
             <li><a href="http://cointelegraph.com/" target="_blank">CoinTelegraph</a></li>
-            <li><a href="http://cointelegraph.com/" target="_blank">CryptoAud.Io</a></li>
+            <li><a href="http://cryptoaud.io/" target="_blank">CryptoAud.Io</a></li>
           </ul>
           <br>
           <h3>Podcasts:</h3>


### PR DESCRIPTION
I've added a link to CryptoAud.Io, a free tool that I've developed for myself and some friends. Basically it's a news aggregator (right now the sources are Cointelegraph and Coindesk, but I am going to add more soon) that automatically creates an article summary you can "listen" in an audio player. It's totally free, no registration required.

I am using it as "sandbox" for some technologies I am studying. :) hope you will like it!