### PR TITLE
Added lightning network stores repository resource

### DIFF
--- a/bitcoin.html
+++ b/bitcoin.html
@@ -585,6 +585,7 @@
             <li><a href="http://lnstat.ideoflux.com:3000/dashboard/db/lightning-network?refresh=5m&orgId=1" target="_blank">Network statistics</a></li>
             <li><a href="http://shabang.io/" target="_blank">More network statistics</a></li>
             <li><a href="https://lnmainnet.gaben.win/" target="_blank">Mainnet Network Graph</a></li>
+            <li><a href="http://lightningnetworkstores.com/" target="_blank">Lightning network stores</a> (<a href="https://github.com/lightningnetworkstores/lightningnetworkstores.github.io" target="_blank">github</a>)</li>
           </ul>
           <br>
           <h3>Fork Stats:</h3>


### PR DESCRIPTION
Added a resource to the Lightning network section: http://lightningnetworkstores.com/ (github is https://github.com/lightningnetworkstores/lightningnetworkstores.github.io)