### PR TITLE
Add Bisq to list of exchanges

### DIFF
--- a/bitcoin.html
+++ b/bitcoin.html
@@ -538,8 +538,8 @@
             <li><a href="https://github.com/PYMERVAL/decentradexchange/blob/master/README.md" target="_blank">List of Decentralized Exchanges</a></li>
             <li><a href="https://bitcoinatmmap.com/" target="_blank">Bitcoin ATM Map</a></li>
             <li><a href="https://coinatmradar.com/" target="_blank">Coin ATM Radar</a></li>
-	    <li><a href="http://www.findbitcoinatm.com.au/" target="_blank">Australian ATMs</a></li>
-	    <li><a href="https://hodlhodl.com/" target="_blank">Hodl Hodl</a></li>
+            <li><a href="http://www.findbitcoinatm.com.au/" target="_blank">Australian ATMs</a></li>
+            <li><a href="https://hodlhodl.com/" target="_blank">Hodl Hodl</a></li>
             <li><a href="https://localbitcoins.com/" target="_blank">Local Bitcoins</a></li>
             <li><a href="https://changelly.com/" target="_blank">Changelly</a></li>
             <li><a href="https://shapeshift.io/" target="_blank">Shapeshift</a></li>

--- a/bitcoin.html
+++ b/bitcoin.html
@@ -539,6 +539,7 @@
             <li><a href="https://bitcoinatmmap.com/" target="_blank">Bitcoin ATM Map</a></li>
             <li><a href="https://coinatmradar.com/" target="_blank">Coin ATM Radar</a></li>
             <li><a href="http://www.findbitcoinatm.com.au/" target="_blank">Australian ATMs</a></li>
+            <li><a href="https://bisq.network/" target="_blank">Bisq</a></li>
             <li><a href="https://hodlhodl.com/" target="_blank">Hodl Hodl</a></li>
             <li><a href="https://localbitcoins.com/" target="_blank">Local Bitcoins</a></li>
             <li><a href="https://changelly.com/" target="_blank">Changelly</a></li>


### PR DESCRIPTION
Bisq was originally added in pull request #47, and was later removed in lieu of a link to a list of decentralized exchanges in commit 24c2fb0ca040837843b42068165e4d2b74d60a88. It seems reasonable to add it back to the main list here at lopp.net, however, as most readers would be hard-pressed to follow the link to the list of decentralized exchanges and correctly assess Bisq's longevity, reputation and position as the only operational decentralized crypto-fiat exchange out there. Thanks for your consideration.