### PR TITLE
Update bitcoin.html adding Tallycoin to Crypto Charity section

### DIFF
--- a/bitcoin.html
+++ b/bitcoin.html
@@ -703,7 +703,7 @@
           <br>
           <h3>Crypto Charity:</h3>
           <ul>
-            <li><a href="https://tallyco.in/" target="_blank">Tallycoin Fundraising Platform</a></li>
+            <li><a href="https://tallyco.in/" target="_blank">Tallycoin Fundraising Platform accepting BTC/Lightning</a></li>
             <li><a href="https://en.bitcoin.it/wiki/Donation-accepting_organizations_and_projects" target="_blank">Charities that accept BTC</a></li>
             <li><a href="http://bitcoinforcharity.com/bitcoin-charity-list/" target="_blank">More BTC acccepting charities</a></li>
             <li><a href="https://www.bitgivefoundation.org/" target="_blank">BitGive</a></li>

--- a/bitcoin.html
+++ b/bitcoin.html
@@ -703,6 +703,7 @@
           <br>
           <h3>Crypto Charity:</h3>
           <ul>
+            <li><a href="https://tallyco.in/" target="_blank">Tallycoin Fundraising Platform</a></li>
             <li><a href="https://en.bitcoin.it/wiki/Donation-accepting_organizations_and_projects" target="_blank">Charities that accept BTC</a></li>
             <li><a href="http://bitcoinforcharity.com/bitcoin-charity-list/" target="_blank">More BTC acccepting charities</a></li>
             <li><a href="https://www.bitgivefoundation.org/" target="_blank">BitGive</a></li>


### PR DESCRIPTION
Request: Add Tallycoin Fundraising Platform under Crypto Charity section.
Description: Tallycoin users bring their own wallet and use the platform to accept donations in bitcoin and lightning.