### PR TITLE
deepdotweb shutdown by law enforcement

### DIFF
--- a/bitcoin-information.html
+++ b/bitcoin-information.html
@@ -463,7 +463,7 @@
             <li><a href="https://cryptoconsortium.github.io/CCSS/" target="_blank" rel="noopener">Cryptocurrency Security Standard</a> (for enterprises)</li>
             <li><a href="https://glacierprotocol.org/" target="_blank" rel="noopener">Glacier: A protocol for high security Bitcoin storage</a></li>
             <li><a href="https://www.youtube.com/watch?v=I1uefzJJ6nM" target="_blank" rel="noopener">Intro to Paper Wallets &amp; Cold Storage</a> (James D'Angelo)</li>
-            <li><a href="https://www.deepdotweb.com/jolly-rogers-security-guide-for-beginners/" target="_blank" rel="noopener">Jolly Roger's Security Guide for Beginners</a> (online OPSEC)</li>
+            <li><a href="https://www.deepdotweb.com/jolly-rogers-security-guide-for-beginners/" target="_blank" rel="noopener">Jolly Roger's Security Guide for Beginners</a> (online OPSEC) <font color="red">(deeptdotweb shutdown on may 19)<font></li>
             <li><a href="https://coinsutra.com/make-bitcoin-paper-wallet-spend-bitcoins/" target="_blank" rel="noopener">Paper Wallet Cold Storage Guide</a> (advanced users only!)</li>
             <li><a href="https://bitcoin.org/en/secure-your-wallet" target="_blank" rel="noopener">Securing Your Wallet</a></li>
             <li><a href="https://medium.com/@lopp/thoughts-on-secure-storage-of-bitcoins-and-other-crypto-assets-210cadabb53d" target="_blank" rel="noopener">Thoughts on Secure Storage of Crypto Assets</a></li>


### PR DESCRIPTION
I noticed today that the link to "Jolly Roger's Security Guide for Beginners" is broken, as the site deepdotweb appears to have been shutdown by law enforcement. I propose to keep the link but add that the site has been shutdown on may 2019.