### PR TITLE
Add list of feerate estimation APIs

### DIFF
--- a/bitcoin-information/fee-estimates.html
+++ b/bitcoin-information/fee-estimates.html
@@ -104,6 +104,7 @@
           <h2 id="tx_fee_estimates">Transaction Fee Estimates:</h2>
           <ul>
             <li><a href="https://p2sh.info/dashboard/db/fee-estimation?orgId=1&from=now-7d&to=now" target="_blank" rel="noopener">Transaction Fee Estimates</a> (many sources)</li>
+            <li><a href="https://b10c.me/A-list-of-public-feerate-estimator-APIs/" target="_blank" rel="noopener">List of feerate estimation APIs</a></li>
             <li><a href="http://statoshi.info/dashboard/db/fee-estimates" target="_blank" rel="noopener">Bitcoin Core Fee Estimates</a></li>
             <li><a href="https://bitcoiner.live/" target="_blank" rel="noopener">Bitcoiner.live</a></li>
             <li><a href="https://bitcoinfees.earn.com/" target="_blank" rel="noopener">Earn.com Fee Estimates</a></li>


### PR DESCRIPTION
Adds a link to a [list](https://b10c.me/A-list-of-public-feerate-estimator-APIs/) containing public feerate APIs.