### PR TITLE
Add LocalCryptos under "Privacy Preserving P2P Exchanges"

### DIFF
--- a/bitcoin-information/buying-earning.html
+++ b/bitcoin-information/buying-earning.html
@@ -161,6 +161,7 @@
             <li><a href="https://hodlhodl.com/" title="Hodl Hodl" target="_blank" rel="noopener">Hodl Hodl</a></li>
             <li><a href="https://otc.huobi.co/en-us/trade/buy-btc/" title="Huobi OTC" target="_blank" rel="noopener">Huobi OTC</a></li>
             <li><a href="https://liberalcoins.com/" title="Liberal Coins" target="_blank" rel="noopener">LiberalCoins</a></li>
+            <li><a href="https://localcryptos.com/" title="LocalCryptos" target="_blank" rel="noopener">LocalCryptos</a></li>
             <li><a href="https://localcoinswap.com/" title="LocalCoinSwap" target="_blank" rel="noopener">LocalCoinSwap</a></li>
             <li><a href="https://www.locallightning.net/" title="Local Lightning" target="_blank" rel="noopener">Local Lightning</a></li>
             <li><a href="https://www.moontrade.org/buy.php" title="Moontrade" target="_blank" rel="noopener">Moontrade</a></li>


### PR DESCRIPTION
This PR adds LocalCryptos to the "Privacy Preserving P2P Exchanges" section.

We are privacy-preserving in that:

* Messages between users are end-to-end encrypted.
* LocalCryptos is non-custodial (the web wallet as well as the escrow service).
* We don't invade users' privacy by asking for personal details.
* There are no third-party trackers like Google Analytics on the platform; only a self-hosted Matomo instance.