### PR TITLE
remove/fix broken lnroute links

### DIFF
--- a/lightning-information.html
+++ b/lightning-information.html
@@ -297,7 +297,6 @@
             <li><a href="https://bitcoinist.com/tag/lightning-network/" title="Bitcoinist" target="_blank" rel="noopener">Bitcoinist</a></li>
             <li><a href="https://bitcoinmagazine.com/tags/lightning-network/" title="Bitcoin Magazine" target="_blank" rel="noopener">Bitcoin Magazine</a></li>
             <li><a href="https://www.theblockcrypto.com/tag/lightning-network/" title="The Block" target="_blank" rel="noopener">The Block</a></li>
-            <li><a href="https://lnroute.com/category/lightning-network-news/" title="LNRoute" target="_blank" rel="noopener">LNRoute News</a></li>
             <li><a href="https://www.coindesk.com/tag/lightning-network" title="CoinDesk" target="_blank" rel="noopener">CoinDesk</a></li>
             <li><a href="https://cointelegraph.com/tags/lightning-network" title="CoinTelegraph" target="_blank" rel="noopener">CoinTelegraph</a></li>
           </ul>
@@ -346,8 +345,7 @@
           <ul>
             <li><a href="https://www.lapps.co/" title="Lapps" target="_blank" rel="noopener">Lapps.co</a></li>
             <li><a href="http://dev.lightning.community/lapps/index.html" title="Lapps Directory" target="_blank" rel="noopener">Lapps Directory</a></li>
-            <li><a href="https://lnroute.com/category/implementations/internet-services/" title="Earn Satoshis" target="_blank" rel="noopener">Apps for earning money</a></li>
-            <li><a href="https://lnroute.com/category/implementations/games/" title="Lightning Games" target="_blank" rel="noopener">LN powered games</a></li>
+            <li><a href="https://lnroute.com/category/games" title="Lightning Games" target="_blank" rel="noopener">LN powered games</a></li>
             <li><a href="https://openline.telspark.com/" title="OpenTel" target="_blank" rel="noopener">OpenTel</a> (pay phone)</li>
             <li><a href="https://ion.radar.tech/apps" title="Radar Tech" target="_blank" rel="noopener">Radar Tech App Store</a></li>
           </ul>
@@ -382,7 +380,7 @@
           <ul>
             <li><a href="https://acceptlightning.com/" title="Merchant List" target="_blank" rel="noopener">Merchant list/map</a></li>
             <li><a href="http://lightningnetworkstores.com/" title="Store List" target="_blank" rel="noopener">LN Stores</a></li>
-            <li><a href="https://lnroute.com/category/implementations/stores/" title="Store List" target="_blank" rel="noopener">LNRoute store list</a></li>
+            <li><a href="https://lnroute.com/category/stores" title="Store List" target="_blank" rel="noopener">LNRoute store list</a></li>
             <li><a href="https://messari.io/resource/lightning-network#heading-6" title="Merchant List" target="_blank" rel="noopener">Messari merchant list</a></li>
           </ul>
           <br />


### PR DESCRIPTION
The design of the website seems to have changed. There's no 'news' or
'earn satoshis' category anymore. The 'games' section is under a different
url, as is the 'stores' section.