### PR TITLE
Adding PayWithMoon Lightning-powered Visa payments app

### DIFF
--- a/lightning-information.html
+++ b/lightning-information.html
@@ -429,6 +429,7 @@
             <li><a href="https://www.opencart.com/index.php?route=marketplace/extension/info&extension_id=36414" title="OpenCart" target="_blank" rel="noopener">OpenCart Payment Gateway</a> (for LND node)</li>
             <li><a href="http://dazaar.com/" title="Dazaar" target="_blank" rel="noopener">Dazaar</a> (A library for selling data over a P2P network)</li>
             <li><a href="https://redshift.radar.tech/" title="REDSHIFT" target="_blank" rel="noopener">REDSHIFT</a> (payment currency swap)</li>
+            <li><a href="https://paywithmoon.com/" title="PayWithMoon" target="_blank" rel="noopener">PayWithMoon</a> (Visa payment swap)</li>
           </ul>
           <br />
           <h2 id="trading">Trading:</h2>


### PR DESCRIPTION
This is a consumer-facing app (not merchant) that probably needs a category of it's own. It allows anyone to pay a Visa-enabled merchant using your Lightning Network funds. Not a wallet.