### PR TITLE
This PR adds Binance to the list of supported exchanges on Bitcoin-DCA

### DIFF
--- a/bitcoin-information/buying-earning.html
+++ b/bitcoin-information/buying-earning.html
@@ -194,7 +194,7 @@
             <li><a href="https://www.bitpanda.com/en/savings" title="Bitpanda" target="_blank" rel="noopener">Bitpanda</a></li>
             <li><a href="https://github.com/Fittiboy/autocoin#autocoin" title="Autocoin" target="_blank" rel="noopener">Bitstamp</a> (DIY)</li>
             <li><a href="https://getbittr.com" title="Bittr" target="_blank" rel="noopener">Bittr</a> (EU)</li>
-            <li><a href="https://github.com/Jorijn/bitcoin-dca/" title="Auto DCA" target="_blank" rel="noopener">BL3P, Bitvavo &amp; Kraken</a> (EU DIY)</li>
+            <li><a href="https://github.com/Jorijn/bitcoin-dca/" title="Auto DCA" target="_blank" rel="noopener">BL3P, Bitvavo, Binance &amp; Kraken</a> (EU DIY)</li>
             <li><a href="https://www.btcmarkets.net/" title="BTC Markets" target="_blank" rel="noopener">BTC Markets</a> (AU)</li>
             <li><a href="https://bullbitcoin.com/recurring-buys" title="Bull" target="_blank" rel="noopener">Bull Bitcoin</a> (CA)</li>
             <li><a href="https://cash.app/help/us/en-us/3109-schedule-automatic-purchases" title="Cash App" target="_blank" rel="noopener">Cash App</a> (US)</li>


### PR DESCRIPTION
About: 

* https://github.com/Jorijn/bitcoin-dca
* https://bitcoin-dca.readthedocs.io/en/latest/