### PR TITLE
Remove hardcore fund link

### DIFF
--- a/bitcoin-information/charity.html
+++ b/bitcoin-information/charity.html
@@ -127,7 +127,6 @@
             <li><a href="https://github.com/BlockchainGuild/BlockchainGuildCommunity" title="Blockchain Guild" target="_blank" rel="noopener">Blockchain Guild</a></li>
             <li><a href="https://brink.dev/" title="Brink" target="_blank" rel="noopener">Brink</a></li>
             <li><a href="https://bitcoindevlist.com/" title="Donation Portal" target="_blank" rel="noopener">Developer Donation Portal</a></li>
-            <li><a href="https://hardcore.fund/" title="Hard Core Fund" target="_blank" rel="noopener">Hard Core Fund</a></li>
             <li><a href="https://hrf.org/bitcoin-development-fund" title="Human Rights Foundation" target="_blank" rel="noopener">Human Rights Foundation</a> (Bitcoin dev fund)</li>
             <li><a href="https://dci.mit.edu/support-our-work" title="MIT DCI" target="_blank" rel="noopener">MIT Digital Currency Initiative</a></li>
             <li><a href="https://polylunar.com/bitcoin-grants-tracker/" title="Grants Tracker" target="_blank" rel="noopener">Grants Tracker</a></li>


### PR DESCRIPTION
Hardcore Fund does not appear to be actively distributing funds to developers. Luke Dashjr who they list as active is no longer receiving funding from them and the site hasn't listed any donations since 2019.