### PR TITLE
Update the typo in the link

### DIFF
--- a/bitcoin-information/careers.html
+++ b/bitcoin-information/careers.html
@@ -132,7 +132,7 @@
             <li><a href="https://www.bitcoinerventures.com" title="Investor Database" target="_blank" rel="noopener">Bitcoiner Ventures</a></li>
             <li><a href="https://www.castleisland.vc/" title="Castle Island" target="_blank" rel="noopener">Castle Island Ventures</a></li>
             <li><a href="https://fulgur.ventures/" title="Fulgur" target="_blank" rel="noopener">Fulgur Ventures</a></li>
-            <li><a href="https://hcm.capital//" title="HCM" target="_blank" rel="noopener">HCM Capital</a></li>
+            <li><a href="https://hcm.capital/" title="HCM" target="_blank" rel="noopener">HCM Capital</a></li>
             <li><a href="https://ltng.ventures/" title="Lightning Ventures" target="_blank" rel="noopener">Lightning Ventures</a></li>
             <li><a href="https://www.mimesiscapital.com/" title="Mimesis" target="_blank" rel="noopener">Mimesis Capital</a></li>
             <li><a href="https://planb-funds.com/" title="Plan B" target="_blank" rel="noopener">Plan B Syndicate</a></li>


### PR DESCRIPTION
Remove redundant '/' resulting in bad redirect for HCM Capital