### PR TITLE
Adding Finbold to news sources and Bitcoin ROI to statistic metrics

### DIFF
--- a/bitcoin-information/exchange-data.html
+++ b/bitcoin-information/exchange-data.html
@@ -120,6 +120,7 @@
             <li><a href="https://www.bitcointradevolume.com/" title="Trade Volume" target="_blank" rel="noopener">Bitcoin Trade Volume</a></li>
             <li><a href="https://bitcoincharts.com/" title="Bitcoin Charts" target="_blank" rel="noopener">Bitcoin Charts</a></li>
             <li><a href="https://bitcoindominance.com/" title="Bitcoin Dominance" target="_blank" rel="noopener">Bitcoin Dominance</a></li>
+            <li><a href="https://finbold.com/bitcoin-roi" title="Bitcoin ROI" target="_blank" rel="noopener">Bitcoin ROI</a> - Compared to TOP stocks</li>
             <li><a href="https://www.viewbase.com/exchange" title="Exchange Balances" target="_blank" rel="noopener">Exchange Balances</a></li>
             <li><a href="https://onchainfx.com/" title="On Chain FX" target="_blank" rel="noopener">Onchain FX</a></li>
             <li><a href="https://coinmarketcap.com/" title="Coin Market Caps" target="_blank" rel="noopener">Coin Market Caps</a></li>

--- a/bitcoin-information/news.html
+++ b/bitcoin-information/news.html
@@ -122,6 +122,7 @@
             <li><a href="http://coinjournal.net/" title="CoinJournal" target="_blank" rel="noopener">CoinJournal</a></li>
             <li><a href="https://www.merklereport.com/" title="Merkle Report" target="_blank" rel="noopener">Merkle Report</a></li>
             <li><a href="https://messari.io/" title="Messari" target="_blank" rel="noopener">Messari</a></li>
+            <li><a href="https://finbold.com/" title="Finbold" target="_blank" rel="noopener">Finbold</a></li>
           </ul>
         </div>
         <!-- RIGHT COLUMN -->

--- a/bitcoin-information/news.html
+++ b/bitcoin-information/news.html
@@ -120,9 +120,9 @@
             <li><a href="https://btctimes.com" title="BTC Times" target="_blank" rel="noopener">BTC Times</a></li>
             <li><a href="http://www.coindesk.com/" title="Coindesk" target="_blank" rel="noopener">Coindesk</a></li>
             <li><a href="http://coinjournal.net/" title="CoinJournal" target="_blank" rel="noopener">CoinJournal</a></li>
+            <li><a href="https://finbold.com/" title="Finbold" target="_blank" rel="noopener">Finbold</a></li>
             <li><a href="https://www.merklereport.com/" title="Merkle Report" target="_blank" rel="noopener">Merkle Report</a></li>
             <li><a href="https://messari.io/" title="Messari" target="_blank" rel="noopener">Messari</a></li>
-            <li><a href="https://finbold.com/" title="Finbold" target="_blank" rel="noopener">Finbold</a></li>
           </ul>
         </div>
         <!-- RIGHT COLUMN -->

--- a/bitcoin-information/statistics-metrics.html
+++ b/bitcoin-information/statistics-metrics.html
@@ -165,7 +165,6 @@
             <li><a href="https://howmanyconfs.com/" title="How Many Confs" target="_blank" rel="noopener">How Many Confs</a> (mining security comparison)</li>
             <li><a href="https://www.usefultulips.org/Combined_World_Page.html" title="P2P Trading" target="_blank" rel="noopener">P2P Trading Volumes</a></li>
             <li><a href="https://tsypruyan.github.io/" title="Tsypruyan" target="_blank" rel="noopener">Tsypruyan</a> - on-chain metrics</li>
-            <li><a href="https://finbold.com/bitcoin-roi" title="Bitcoin ROI" target="_blank" rel="noopener">Bitcoin ROI</a> - Compared to TOP stocks</li>
           </ul>
         </div>
       </div>

--- a/bitcoin-information/statistics-metrics.html
+++ b/bitcoin-information/statistics-metrics.html
@@ -165,6 +165,7 @@
             <li><a href="https://howmanyconfs.com/" title="How Many Confs" target="_blank" rel="noopener">How Many Confs</a> (mining security comparison)</li>
             <li><a href="https://www.usefultulips.org/Combined_World_Page.html" title="P2P Trading" target="_blank" rel="noopener">P2P Trading Volumes</a></li>
             <li><a href="https://tsypruyan.github.io/" title="Tsypruyan" target="_blank" rel="noopener">Tsypruyan</a> - on-chain metrics</li>
+            <li><a href="https://finbold.com/bitcoin-roi" title="Bitcoin ROI" target="_blank" rel="noopener">Bitcoin ROI</a> - Compared to TOP stocks</li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
Finbold is trusted news source that is already being aggregated by top news aggregator sites such as CryptoPanic, CMC, CoinGecko etc. Similarweb reports 2M+ monthly page views.

Bitcoin ROI by Finbold is data driven interactive, that allows users to compare Bitcoin return of investment in different time frames against the most popular stocks, indexes and commodities. 