### PR TITLE
Updated RaspiBolt guide URL

### DIFF
--- a/bitcoin-information/full-node.html
+++ b/bitcoin-information/full-node.html
@@ -125,7 +125,7 @@
             <li><a href="https://github.com/dgarage/hack0-hardware" title="Hack0" target="_blank" rel="noopener">Hack0 Build Guide</a></li>
             <li><a href="https://github.com/lightning-power-users/node-launcher" title="Node Launcher" target="_blank" rel="noopener">Node Launcher</a></li>
             <li><a href="https://medium.com/@meeDamian/bitcoin-full-node-on-rbp3-revised-88bb7c8ef1d1" title="Pi Guide" target="_blank" rel="noopener">Raspberry Pi Node Guide</a></li>
-            <li><a href="https://stadicus.github.io/RaspiBolt/" title="RaspiBolt" target="_blank" rel="noopener">RaspiBolt Guide</a></li>
+            <li><a href="https://raspibolt.org/" title="RaspiBolt" target="_blank" rel="noopener">RaspiBolt Guide</a></li>
             <li><a href="https://samouraiwallet.com/dojo" title="Dojo" target="_blank" rel="noopener">Samourai Dojo</a></li>
             <li><a href="https://mynodebtc.com/download" title="myNode" target="_blank" rel="noopener">myNode</a></li>
             <li><a href="https://getumbrel.com/" title="Umbrel" target="_blank" rel="noopener">umbrel</a></li>


### PR DESCRIPTION
A small PR just to update the RaspiBolt guide URL. The project now has its own domain at [https://raspibolt.org/](https://raspibolt.org/)

Thanks!