### PR TITLE
Update stekking to satsback.com

### DIFF
--- a/bitcoin-information/buying-earning.html
+++ b/bitcoin-information/buying-earning.html
@@ -221,7 +221,7 @@
           <ul>
             <li><a href="https://foldapp.com/" title="Fold" target="_blank" rel="noopener">Fold</a></li>
             <li><a href="https://www.lolli.com/" title="Lolli" target="_blank" rel="noopener">Lolli</a></li>
-            <li><a href="https://stekking.com/" title="Stekking" target="_blank" rel="noopener">Stekking</a></li>
+            <li><a href="https://satsback.com/" title="Satsback" target="_blank" rel="noopener">Satsback</a></li>
           </ul>
           <h2 id="strategies"><a href="#strategies">Buying &amp; Selling Strategies:</a></h2>
           <ul>


### PR DESCRIPTION
Stekking.com is now [Satsback.com](https://satsback.com/)