### PR TITLE
Update privacy.html

### DIFF
--- a/bitcoin-information/privacy.html
+++ b/bitcoin-information/privacy.html
@@ -130,9 +130,9 @@
             <li><a href="https://github.com/JoinMarket-Org/joinmarket-clientserver" title="JoinMarket" target="_blank" rel="noopener">JoinMarket</a> (CoinJoin software)</li>
             <li><a href="https://www.kycp.org/" title="Know Your Coin" target="_blank" rel="noopener">Know Your Coin Privacy</a></li>
             <li><a href="https://github.com/NTumbleBit/NTumbleBit" title="TumbleBit" target="_blank" rel="noopener">NTumbleBit</a></li>
-            <li><a href="https://wasabiwallet.io/" title="Wasabi" target="_blank" rel="noopener">Wasabi Wallet</a> (CoinJoin software)</li>
-            <li><a href="https://github.com/Samourai-Wallet/Whirlpool" title="Whirlpool" target="_blank" rel="noopener">Whirlpool</a> (CoinJoin software)</li>
-            <li><a href="https://github.com/nopara73/ZeroLink/" title="Zerolink" target="_blank" rel="noopener">ZeroLink</a></li>
+            <li><a href="https://sparrowwallet.com/" title="Sparrow Wallet" target="_blank" rel="noopener">Sparrow Wallet</a> (CoinJoin software)</li>
+            <li><a href="https://www.samouraiwallet.com/whirlpool" title="Whirlpool" target="_blank" rel="noopener">Whirlpool</a> (CoinJoin software)</li>
+            <li><a href="https://code.samourai.io/whirlpool/Whirlpool" title="Zerolink" target="_blank" rel="noopener">ZeroLink</a></li>
           </ul>
         </div>
         <!-- RIGHT COLUMN -->


### PR DESCRIPTION
Wasabi will now be censoring UTXOs and utilising chain analysis companies so suggest Sparrow is the alternative recommendation now. Links updated for Zerolink (Wasabi is deprecating this) and this is now used by Sparrow. Link for Samourai Whirlpool updated to their self hosted Gitlab.