### PR TITLE
Issue Fix: #513 Move dark mode toggle to nav

### DIFF
--- a/bitcoin-information.html
+++ b/bitcoin-information.html
@@ -32,6 +32,8 @@
 
   <link rel="stylesheet" href="/css/bootstrap.css" />
   <link id="mystyle" rel="stylesheet" href="/css/style.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.2/css/font-awesome.min.css">
+  <link rel="stylesheet" href="/css/darkmodetoggle.css">
 
   <script async src="/js/ga4.js"></script>
   <script>
@@ -72,6 +74,7 @@
           <li class="active"><a href="#" title="bitcoin info">Bitcoin Resources<span class="sr-only">(current)</span></a></li>
           <li><a href="lightning-information" title="lightning info">Lightning Resources</a></li>
           <li><a href="contact" title="contact">Contact</a></li>
+          <li><input class="toggle-input" type="checkbox" aria-label="toggle dark mode" id="permanent"/><label for="permanent"></label></li>
         </ul>
       </div>
     </div>
@@ -83,17 +86,7 @@
         <div class="col-xs-12 text-left col-lg-offset-1 col-lg-8 col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1">
           <h1>Bitcoin Information &amp; Resources</h1>
           <p>What is Bitcoin? Bitcoin is a new form of money that is controlled by no one and is developed as an open collaborative project. Below you'll find enough curated educational resources and information about it that you could spend months sifting through them all. Make sure you have a decent understanding of the system before you store a significant amount of value in it! The same aspects that make it so valuable also make it unforgiving to those who make mistakes.</p>
-          <p>Note that this list is open source; please <a href="https://github.com/jlopp/lopp.net/tree/master/bitcoin-information">suggest changes on Github</a>! Toggle dark mode:</p>
-          <div class="wrapper">
-            <div class="toggle">
-              <input class="toggle-input" type="checkbox" aria-label="toggle dark mode" />
-              <div class="toggle-bg"></div>
-              <div class="toggle-switch">
-                <div class="toggle-switch-figure"></div>
-                <div class="toggle-switch-figureAlt"></div>
-              </div>
-            </div>
-          </div>
+          <p>Note that this list is open source; please <a href="https://github.com/jlopp/lopp.net/tree/master/bitcoin-information">suggest changes on Github</a>!<br/><br/></p>
         </div>
       </div>
     </div>

--- a/css/darkmodetoggle.css
+++ b/css/darkmodetoggle.css
@@ -1,4 +1,4 @@
 @charset "UTF-8";
-input[type=checkbox] {display: none;}input[type=checkbox] + label {padding:8px 0 0 0;display: inline-block;font-size: 22px;}
+input[type=checkbox] {display: none;}input[type=checkbox] + label {padding:8px 0 0 4px;display: inline-block;font-size: 22px;}
 input[type=checkbox] + label:before {content: "\f185";display: inline-block;font-size: inherit;text-rendering: auto;-webkit-font-smoothing: antialiased;font-family: FontAwesome;}
 input[type=checkbox]:checked + label:before {content: "\f186";display: inline-block;font-size: inherit;text-rendering: auto;-webkit-font-smoothing: antialiased;font-family: FontAwesome;}

--- a/css/darkmodetoggle.css
+++ b/css/darkmodetoggle.css
@@ -1,0 +1,4 @@
+@charset "UTF-8";
+input[type=checkbox] {display: none;}input[type=checkbox] + label {padding:8px 0 0 0;display: inline-block;font-size: 22px;}
+input[type=checkbox] + label:before {content: "\f185";display: inline-block;font-size: inherit;text-rendering: auto;-webkit-font-smoothing: antialiased;font-family: FontAwesome;}
+input[type=checkbox]:checked + label:before {content: "\f186";display: inline-block;font-size: inherit;text-rendering: auto;-webkit-font-smoothing: antialiased;font-family: FontAwesome;}

--- a/lightning-information.html
+++ b/lightning-information.html
@@ -108,6 +108,7 @@
           </form>
           <h2 id="getting_started"><a href="#getting_started">Getting Started:</a></h2>
           <ul>
+            <li><a href="https://www.swanbitcoin.com/a-look-at-the-lightning-network/" title="A Look at the Lightning Network" target="_blank" rel="noopener">A Look at the Lightning Network</a></li>
             <li><a href="https://www.youtube.com/watch?v=rrr_zPmEiME" title="ELI5" target="_blank" rel="noopener">Explain it Like I'm 5</a></li>
             <li><a href="https://www.coincenter.org/education/key-concepts/lightning-network/" title="ELI25" target="_blank" rel="noopener">Explain it Like I'm 25</a></li>
             <li><a href="https://letstalkbitcoin.com/blog/post/the-lightning-network-elidhdicacs" title="Explain it Like I Don't Have a Degree in Computer Science" target="_blank" rel="noopener">Explained in layman's terms</a></li>


### PR DESCRIPTION
Referencing Issue #513 "Move dark mode toggle to nav"

I updated the Darkmode Toggle and added it to the Navbar in bitcoin-information.html. If this PR is approved, I can run through the site and add it everywhere.

Steps:

1. Added a new CSS file called "darkmodetoggle.css"
2. Added two calls in bitcoin-information.html: 1) FontAwesome (for sun/moon icons), and 2) darkmodetoggle.css
3. Deleted the old toggle and the text: "Toggle Dark Mode:"
4. Moved the updated Darkmode Toggle to the NavBar
5. Downloaded the ZIP and tested the new toggle successfully

Final Steps (if approved):

1. Delete old CSS for the old toggle
2. Populate the new toggle across all pages