### PR TITLE
Fix bugs in check_links.py script

### DIFF
--- a/check_links.py
+++ b/check_links.py
@@ -4,18 +4,14 @@ import bs4
 from requests import get
 from tqdm import tqdm
 import webbrowser
-import pyinputplus as pyip
 from fake_headers import Headers
 from random import shuffle
-import validators
+
+# Gets script location. Assumes the script is in the lopp.net folder.
+website_directory = os.path.dirname(os.path.realpath(__file__))
+os.chdir(website_directory)
 
 # Create a list of all the HTML files in lopp.net
-all_html_files = []
-website_directory = pyip.inputFilepath(
-    prompt="Enter the path to the website directory: "
-)
-all_html_files = []
-os.chdir(website_directory)
 all_html_files = []
 for root, dirs, files in os.walk(os.getcwd()):
     for file in files:
@@ -31,24 +27,23 @@ for html_file in all_html_files:
             all_links.append(link.get("href"))
 
 # Remove all duplicate links and those pointing to other pages in lopp.net
-print(f"Total number of links: {len(all_links)}")
+print(f"Total number of links before processing: {len(all_links)}")
 all_links = list(set(all_links))  # Removes duplicate links
 shuffle(
     all_links
 )  # We don't want to visit the same page twice in a row, so shuffle the list
 
-for link in all_links:
-    if validators.url(link) == False:
-        # If the link is not a valid URL, remove it
-        all_links.remove(link)
-    elif link.find("lopp.net") != -1:
-        # Ignores the link if it points to one of the other pages in lopp.net or blog.lopp.net
-        all_links.remove(link)
-    elif link[0] == "#" or link[0] == "/":
-        # Ignores the link if it is a link to a specific section of the page
-        all_links.remove(link)
+# For some reason, not all the links are removed in one pass so we keep doing it until we've actually removed all the unwanted links
+for i in range(5):
+    for link in all_links:
+        if link[:4] != "http":
+            # If the link is not a valid URL, remove it
+            all_links.remove(link)
+        elif link.find("lopp.net") != -1:
+            # Ignores the link if it points to one of the other pages in lopp.net or blog.lopp.net
+            all_links.remove(link)
 
-print(f"Total number of links: {len(all_links)}")
+print(f"Total number of links after processing: {len(all_links)}")
 
 # Iterate over each link and download the page with requests
 failed_links = []
@@ -83,12 +78,11 @@ for link in tqdm(failed_links):
 print("Finished checking links with a timeout of 10 seconds")
 print(f"Number of failed links: {len(failed_links)}")
 
-print(failed_links)
 really_failed_links = []
 
 for link in failed_links:
     webbrowser.open_new_tab(link)
-    if pyip.inputYesNo("Is this link working? ") == "no":
+    if input("Is this link working?[y]/n ") == "n":
         really_failed_links.append(link)
 
 # Search all the HTML files for the failed links and print them out


### PR DESCRIPTION
The check_links.py script was still making stupid mistakes when it came to filtering out the unwanted links. After spending over an hour trying to figure it out and approaching the problem from multiple angles I solved it in a stupidly simply way by just putting the links through the filter multiple times. I am still unsure of why that works. I know that Python's
```python
list.remove(x)
```
only removes the first occurrence but the script shouldn't have any duplicates.  Keynes was mostly full of crap, but perhaps he was on to something with his "animal spirits." Anyway, everything it tries to download is now a correct outside link not to another lopp.net subdomain.

#### The other minor fixes are:

- Now you don't have to enter the path to the website directory anymore as it now assumes that it is already in the website directory.
- I was also able to remove two third party dependencies from the script to make it only use two packages outside of the Python standard library.