### PR TITLE
Add mempool.space to list of Lighting explorers

### DIFF
--- a/lightning-information.html
+++ b/lightning-information.html
@@ -316,6 +316,7 @@
             <li><a href="https://1ml.com/" title="1ML" target="_blank" rel="noopener">1ML</a></li>
             <li><a href="https://explorer.acinq.co" title="ACINQ" target="_blank" rel="noopener">ACINQ</a></li>
             <li><a href="https://amboss.space/" title="Amboss" target="_blank" rel="noopener">Amboss</a></li>
+            <li><a href="https://mempool.space/lightning" title="mempool.space" target="_blank" rel="noopener">mempool.space</a></li>
             <li><a href="https://github.com/xsb/lngraph" title="Run Your Own Explorer" target="_blank" rel="noopener">Private Explorer Software</a></li>
             <li><a href="https://bl.ocks.org/tyzbit/d1c83732d2767bb955125d41f5921888" title="Virtual Reality Explorer" target="_blank" rel="noopener">VR Explorer</a></li>
           </ul>


### PR DESCRIPTION
Add mempool.space to the list of Lightning explorers. It's not currently in the "Extensive List of Explorers" resource, and since it's more than a visualization, I think a case can be made to include it as a first class entity in this list.