### PR TITLE
Improve asynchronous downloading in link checker to avoid being blocked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
I added a step in the link checker's asynchronous downloading option to sort the links by their top level domain and then only download one link at a time from each of those top level domains. This does mean a significant decrease in speed, although it is still far faster than the synchronous downloading option.

I also added a gitignore file to make sure no one accidentally commits an internal macOS file.