### PR TITLE
Remove two abandoned node UI projects

### DIFF
--- a/bitcoin-information/full-node.html
+++ b/bitcoin-information/full-node.html
@@ -120,8 +120,6 @@
             <li><a href="https://github.com/Mirobit/bitcoin-node-manager" title="node manager" target="_blank" rel="noopener">Bitcoin Node Manager</a></li>
             <li><a href="https://github.com/craigwatson/bitcoind-status" title="bitcoind status" target="_blank" rel="noopener">bitcoind status</a></li>
             <li><a href="https://github.com/bitseed-org/bitseed-web-ui-2" title="Bitseed" target="_blank" rel="noopener">Bitseed</a></li>
-            <li><a href="https://github.com/loganmarchione/docker-bitcoind-status" title="bitcoind status" target="_blank" rel="noopener">docker bitcoind status</a></li>
-            <li><a href="https://github.com/esotericnonsense/bitcoind-ncurses2" title="ncurses" target="_blank" rel="noopener">Ncurses</a></li>
             <li><a href="https://github.com/wintercooled/NodeMonitor-Python-Django" title="node monitor" target="_blank" rel="noopener">Node Monitor</a></li>
             <li><a href="https://github.com/curly60e/pyblock" title="pyblock" target="_blank" rel="noopener">Pyblock</a></li>
             <li><a href="https://github.com/pxsocs/warden_terminal" title="warden" target="_blank" rel="noopener">WARden</a></li>


### PR DESCRIPTION
Removed the links for two projects that tried to provide a nice UI for a bitcoin node so you could easily browse their information. The first project called docker-bitcoind-status has had its repo archived and its own README now states:

> This project relies on an API that is not reliable. As such, I will
> not be updating this code.

The other repo, ncurses2, hasn't had a commit in five years and the program crashes immediately upon startup.