### PR TITLE
Add link to HAB Guide

### DIFF
--- a/bitcoin-information/full-node.html
+++ b/bitcoin-information/full-node.html
@@ -115,6 +115,7 @@
             <li><a href="https://samouraiwallet.com/dojo" title="Dojo" target="_blank" rel="noopener">Samourai Dojo</a></li>
             <li><a href="https://mynodebtc.com/download" title="myNode" target="_blank" rel="noopener">myNode</a></li>
             <li><a href="https://getumbrel.com/" title="Umbrel" target="_blank" rel="noopener">umbrel</a></li>
+            <li><a href="https://gildedpleb.github.io/hab-guide/" title="HAB Guide" target="_blank" rel="noopener">Highly Available Bitcoin Node</a></li>
           </ul>
           <h2 id="dashboards"><a href="#dashboards">Full Node Dashboards:</a></h2>
           <ul>


### PR DESCRIPTION
This RP adds a link to a fully FOSS guide for how to make a Highly Available Bitcoin Node. 

https://gildedpleb.github.io/hab-guide/

More info can be found at the link but the general premise is this: 

HAB Nodes remove single points of failure in node operation for plebs. 

Single Sig Tx : Multisig :: Single Bitcoin Node : HAB Node

- [x] `Resources that are highly similar to existing resources need to be substantially better in some way`: No other guides are like this one, this is fundamentally new node architecture for plebs. 
- [x] `Resources that are clearly built as referral revenue mechanisms will be rejected`: There are no referrals for revenue.
- [x] `Services that are new and have the potential to be scams will be held indefinitely until they have proven their reputation`: This is not a service. This is a new application of k8s and Bitcoin on bare metal. It is not a scam (and I struggle to see how it could be), but it does not have a proven reputation. Appropriate warnings about key management are included in the guide (namely: DO NOT use a HAB Node to defend private keys for real bitcoin).

That said, I submit that this HAB Guide may be eligible to be included with the other excellent resources I have made use of at lopp.net over the years. 

Thank you Lopp for your hard work and dedication to the space! 

