### PR TITLE
Add Bitcoin Reserve Podcast/YouTube links

### DIFF
--- a/bitcoin-information/podcasts.html
+++ b/bitcoin-information/podcasts.html
@@ -115,6 +115,7 @@
             <li><a href="https://www.bitcoin.kn/" title="Bitcoin Knowledge" target="_blank" rel="noopener">Bitcoin Knowledge Podcast</a></li>
             <li><a href="https://bitcoinops.org/en/podcast/" title="Optech" target="_blank" rel="noopener">Bitcoin Optech</a></li>
             <li><a href="https://anchor.fm/john-vallis" title="Rapid Fire" target="_blank" rel="noopener">Bitcoin Rapid-Fire</a></li>
+            <li><a href="https://anchor.fm/bitcoin-reserve" title="The Bitcoin Reserve Podcast" target="_blank" rel="noopener">The Bitcoin Reserve Podcast</a></li>
             <li><a href="https://anchor.fm/bitcoinreview" title="Bitcoin Review" target="_blank" rel="noopener">Bitcoin Review</a> (of software updates)</li>
             <li><a href="https://saifedean.com/podcast/" title="Bitcoin Standard" target="_blank" rel="noopener">The Bitcoin Standard</a></li>
             <li><a href="https://bitcoin-takeover.com/audio/" title="Bitcoin Takeover" target="_blank" rel="noopener">Bitcoin Takeover Podcast</a></li>
@@ -162,6 +163,7 @@
           <ul>
             <li><a href="https://github.com/Xel/Blockchain-stuff#youtube-channels" title="YouTube List" target="_blank" rel="noopener">Epic List of YouTube Channels</a></li>
             <li><a href="https://www.youtube.com/user/aantonop/videos" title="Andreas Antonopoulos" target="_blank" rel="noopener">Andreas Antonopoulos</a></li>
+            <li><a href="https://www.youtube.com/@bitcoinreserve" title="Bitcoin Reserve" target="_blank" rel="noopener">Bitcoin Reserve</a></li>
             <li><a href="https://www.youtube.com/channel/UCzdDFk3EYSyHr4eMMIxRBrg" title="Bitcoin Takeover" target="_blank" rel="noopener">Bitcoin Takeover</a></li>
             <li><a href="https://www.youtube.com/c/blockdigest" title="Block Digest" target="_blank" rel="noopener">Block Digest</a></li>
             <li><a href="https://www.youtube.com/playlist?list=PLseHpvCI1BjDxlmM9FrFPKYzktE8kts9L" title="Blockstream Talk" target="_blank" rel="noopener">Blockstream Talk</a></li>


### PR DESCRIPTION
Adding Bitcoin Reserve podcast and YouTube links.

Reference:
- "Feel free to submit a pull request to add your podcast to my resources site..." - https://twitter.com/lopp/status/1633124128885465089?s=46&t=5Vi2dEZ0ov1NaAKGdg84FA