### PR TITLE
Add Athena Alpha (Bitcoin Education) Links

### DIFF
--- a/bitcoin-information/other-resources.html
+++ b/bitcoin-information/other-resources.html
@@ -111,6 +111,7 @@
             <li><a href="https://dergigi.com/bitcoin/resources/" title="Der Gigi" target="_blank" rel="noopener">Gigi's Bitcoin Resources</a></li>
             <li><a href="https://docs.google.com/spreadsheets/d/1Z3Ofa4P8097VWV70Z_bMqIMladngvm-Ck24ot9TDNmw/edit#gid=0" title="Practical Info" target="_blank" rel="noopener">Practical Bitcoin Info</a></li>
             <li><a href="https://river.com/learn/" title="River" target="_blank" rel="noopener">River's Bitcoin Learning Center</a></li>
+            <li><a href="https://www.athena-alpha.com/" title="Bitcoin Education - Athena Alpha" target="_blank" rel="noopener">Bitcoin Education - Athena Alpha</a></li>
           </ul>
         </div>
         <!-- RIGHT COLUMN -->

--- a/bitcoin-information/privacy.html
+++ b/bitcoin-information/privacy.html
@@ -110,6 +110,7 @@
             <li><a href="https://medium.com/human-rights-foundation-hrf/privacy-and-cryptocurrency-part-i-how-private-is-bitcoin-e3a4071f8fff" title="Privacy Primer" target="_blank" rel="noopener">Bitcoin Privacy Primer</a></li>
             <li><a href="https://web.archive.org/web/20200714004203/https://joinmarket.me/blog/blog/tumblebit-for-the-tumble-curious/" title="TumbleBit" target="_blank" rel="noopener">How TumbleBit Works</a></li>
             <li><a href="https://github.com/OpenBitcoinPrivacyProject/wallet-ratings/blob/master/report-02/threat%20model.wiki" title="Open Bitcoin Privacy Project" target="_blank" rel="noopener">Open Bitcoin Privacy Project Threat Model</a></li>
+            <li><a href="https://www.athena-alpha.com/bitcoin-privacy/" title="A Beginners Guide To Bitcoin Privacy" target="_blank" rel="noopener">A Beginners Guide To Bitcoin Privacy</a></li>
           </ul>
           <h2 id="software"><a href="#software">Privacy Software:</a></h2>
           <ul>

--- a/bitcoin-information/security.html
+++ b/bitcoin-information/security.html
@@ -120,6 +120,7 @@
             <li><a href="https://blog.keys.casa/the-dos-and-donts-of-bitcoin-key-management/" title="The Dos and Donts of Key Management" target="_blank" rel="noopener">The Dos and Don'ts of Key Management</a></li>
             <li><a href="https://bitcoin.org/en/secure-your-wallet" title="Wallet Security" target="_blank" rel="noopener">Securing Your Wallet</a></li>
             <li><a href="https://github.com/BlockchainCommons/SmartCustodyBook" title="Smart Custody" target="_blank" rel="noopener">Smart Custody Book</a></li>
+            <li><a href="https://www.athena-alpha.com/bitcoin-security/" title="A Beginners Guide To Bitcoin Security" target="_blank" rel="noopener">A Beginners Guide To Bitcoin Security</a></li>
           </ul>
           <h2 id="checks"><a href="#checks">Security Checks:</a></h2>
           <ul>


### PR DESCRIPTION
Added 3 links as your site states: "please suggest changes on Github!"

Links are for:
1. Our main site under the Other Resources area
2. Our Beginners Security Guide under the Security area
3. Our Beginners Privacy Guide under the Privacy area

We have many other excellent guides / long form pieces but don't want to spam. Please let us know if you'd like more and we can suggest further changes :)
