### PR TITLE
Added mempol-server and mempool-client

### DIFF
--- a/bitcoin-information/developer-tools.html
+++ b/bitcoin-information/developer-tools.html
@@ -139,6 +139,8 @@
             <li><a href="https://github.com/stevenroose/hal" title="hal" target="_blank" rel="noopener">hal</a> (rust CLI utilities)</li>
             <li><a href="https://iancoleman.io/bip39/" title="BIP39 Tools" target="_blank" rel="noopener">HD Key Derivation Tool</a></li>
             <li><a href="https://github.com/dev7ba/mempoolcp" title="Mempoolcp" target="_blank" rel="noopener">Mempoolcp</a> (mempool copy between nodes)</li>
+            <li><a href="https://github.com/dev7ba/mempool-server" title="Mempool-server" target="_blank" rel="noopener">Mempool-server</a> (mempool download)</li>
+            <li><a href="https://github.com/dev7ba/mempool-client" title="Mempool-client" target="_blank" rel="noopener">Mempool-client</a> (mempool download)</li>
             <li><a href="https://github.com/MuleTools/MuleTools" title="Mule Tools" target="_blank" rel="noopener">Mule Tools</a> (alternative txn broadcasting)</li>
             <li><a href="https://github.com/vulpemventures/nigiri" title="Nigiri" target="_blank" rel="noopener">Nigiri</a> (regtest docker setup)</li>
             <li><a href="https://github.com/LarryRuane/minesim" title="network simulator" target="_blank" rel="noopener">PoW Network Simulator</a></li>


### PR DESCRIPTION
I have worked on a couple of projects in Rust that might be useful to someone. 

https://github.com/dev7ba/mempool-client
https://github.com/dev7ba/mempool-server

In recent months, the mempool has been on fire, and when you're starting a Bitcoin node from scratch, it can take a long time to synchronize the mempool and be able to estimate fees on your own (e.g., Sparrow Wallet).

With these two projects you have the option to download the mempool from mempoolexplorer.com and dump it into your node so that you don't have to wait for the mempool to synchronize. You can also configure your own mempool server so that other people can download your mempool.

For more information, take a look at https://mempoolexplorer.com/download.

Thanks.