### PR TITLE
Add year to documentaries.html

### DIFF
--- a/bitcoin-information/documentaries.html
+++ b/bitcoin-information/documentaries.html
@@ -100,35 +100,35 @@
         <div class="text-left col-xs-12 col-sm-6 col-lg-6 col-md-6">
           <h2 id="documentaries"><a href="#documentaries">Documentaries:</a></h2>
           <ul>
-            <li><a href="https://www.amazon.com/Banking-Africa-Revolution-Tamarin-Gerriety/dp/B088Q5BYVR" title="Banking on Africa" target="_blank" rel="noopener">Banking on Africa - The Bitcoin Revolution</a></li>
-            <li><a href="https://vimeo.com/226777744" title="Banking on Bitcoin" target="_blank" rel="noopener">Banking on Bitcoin</a></li>
-            <li><a href="https://www.amazon.com/Bit-Bitcoin-We-Trust/dp/B07PNDD2HH" title="In Bitcoin We Trust" target="_blank" rel="noopener">Bit x Bit: In Bitcoin We Trust</a></li>
-            <li><a href="https://www.youtube.com/user/Bitcoinfilm/videos" title="Bitcoin Films" target="_blank" rel="noopener">Bitcoin Films</a></li>
-            <li><a href="https://www.youtube.com/watch?v=LszOt51OjXU" title="Beyond the Bubble" target="_blank" rel="noopener">Bitcoin: Beyond the Bubble</a></li>
-            <li><a href="https://www.amazon.com/Bitcoin-End-Money-As-Know/dp/B013HU3WX6" title="The End of Money" target="_blank" rel="noopener">Bitcoin: The End of Money as We Know It</a></li>
-            <li><a href="https://www.youtube.com/playlist?list=PL2puemdUi8nDL1tQX0tbRI5-nu11PEWUM" title="Cointelegraph" target="_blank" rel="noopener">Cointelegraph Documentaries</a></li>
-            <li><a href="http://www.deepwebthemovie.com" title="Deep Web" target="_blank" rel="noopener">Deep Web</a></li>
-            <li><a href="https://www.dirtycointhemovie.com/" title="Dirty Coin" target="_blank" rel="noopener">Dirty Coin</a> (mining documentaries)</li>
-            <li><a href="https://www.youtube.com/watch?v=HUpGHOLkoXs" title="Evolution" target="_blank" rel="noopener">Evolution of Bitcoin</a></li>
-            <li><a href="https://www.whatbitcoindid.com/wbd-films" title="Follow the Money" target="_blank" rel="noopener">Follow the Money</a></li>
-            <li><a href="https://www.hardmoneyfilm.com/" title="Hard Money" target="_blank" rel="noopener">Hard Money</a></li>
-            <li><a href="https://www.joincolossus.com/episodes/39800754/lowin-hash-power-part-1" title="Hash Power" target="_blank" rel="noopener">Hash Power</a></li>
-            <li><a href="https://vimeo.com/658711759?s=08" title="Human B" target="_blank" rel="noopener">Human B</a>(German w/English subtitles)</li>
-            <li><a href="https://www.youtube.com/watch?v=_0axyH2X6mI" title="Inside Man" target="_blank" rel="noopener">Inside Man</a> (Morgan Spurlock)</li>
-            <li><a href="https://www.youtube.com/watch?v=K8kua5B5K3I" title="Secret Chinese Mine" target="_blank" rel="noopener">Life Inside a Secret Chinese Bitcoin Mine</a></li>
-            <li><a href="https://www.amazon.com/Life-Bitcoin-Austin-M-Craig/dp/B073RQ64FN" title="Life on Bitcoin" target="_blank" rel="noopener">Life on Bitcoin</a></li>
-            <li><a href="https://www.youtube.com/watch?v=PVo5wCSnmSs" title="Magic Money" target="_blank" rel="noopener">Magic Money: The Bitcoin Revolution</a></li>
-            <li><a href="https://vimeo.com/112223859" title="Bitcoin Doco" target="_blank" rel="noopener">The Bitcoin Doco 1</a> <a href="https://vimeo.com/137032828" title="Bitcoin Doco" target="_blank" rel="noopener"> &amp; 2</a></li>
-            <li><a href="https://www.amazon.com/Bitcoin-Experiment-Pal-Karleson/dp/B01JBA8HYK/" title="Bitcoin Experiment" target="_blank" rel="noopener">The Bitcoin Experiment</a></li>
-            <li><a href="https://www.youtube.com/watch?v=2I6dXRK9oJo" title="Bitcoin Gospel" target="_blank" rel="noopener">The Bitcoin Gospel</a></li>
-            <li><a href="https://www.youtube.com/watch?v=6pWblf8COH4" title="Bitcoin Phenomenon" target="_blank" rel="noopener">The Bitcoin Phenomenon</a></li>
-            <li><a href="https://www.amazon.com/Bitcoin-Story-Gavin-Andresen/dp/B00V0RZZEI/" title="Bitcoin Story" target="_blank" rel="noopener">The Bitcoin Story</a></li>
-            <li><a href="https://blockchain-documentary.com/" title="Blockchain and Us" target="_blank" rel="noopener">The Blockchain and Us</a></li>
-            <li><a href="http://bitcoindoc.com/" title="Rise and Rise" target="_blank" rel="noopener">The Rise and Rise of Bitcoin</a></li>
-            <li><a href="https://www.rt.com/shows/to-the-moon/" title="To the Moon" target="_blank" rel="noopener">To the Moon</a></li>
-            <li><a href="https://youtu.be/ZKwqNgG-Sv4" title="Trust Machine" target="_blank" rel="noopener">The Trust Machine</a> (the history of Bitcoin &amp; money)</li>
-            <li><a href="https://www.amazon.com/gp/video/detail/B07Y15C7G2/" title="Trust Machine" target="_blank" rel="noopener">Trust Machine</a> - The Story of Blockchain</li>
-            <li><a href="https://www.youtube.com/watch?v=yQGQXy0RIIo" title="Ulterior States" target="_blank" rel="noopener">Ulterior States</a></li>
+            <li><a href="https://www.amazon.com/Banking-Africa-Revolution-Tamarin-Gerriety/dp/B088Q5BYVR" title="Banking on Africa" target="_blank" rel="noopener">Banking on Africa - The Bitcoin Revolution</a> (2020)</li>
+            <li><a href="https://vimeo.com/226777744" title="Banking on Bitcoin" target="_blank" rel="noopener">Banking on Bitcoin</a> (2017)</li>
+            <li><a href="https://www.amazon.com/Bit-Bitcoin-We-Trust/dp/B07PNDD2HH" title="In Bitcoin We Trust" target="_blank" rel="noopener">Bit x Bit: In Bitcoin We Trust</a> (2019)</li>
+            <li><a href="https://www.youtube.com/user/Bitcoinfilm/videos" title="Bitcoin Films" target="_blank" rel="noopener">Bitcoin Films</a> (2013-2021)</li>
+            <li><a href="https://www.youtube.com/watch?v=LszOt51OjXU" title="Beyond the Bubble" target="_blank" rel="noopener">Bitcoin: Beyond the Bubble</a> (2018)</li>
+            <li><a href="https://www.amazon.com/Bitcoin-End-Money-As-Know/dp/B013HU3WX6" title="The End of Money" target="_blank" rel="noopener">Bitcoin: The End of Money as We Know It</a> (2015)</li>
+            <li><a href="https://www.youtube.com/playlist?list=PL2puemdUi8nDL1tQX0tbRI5-nu11PEWUM" title="Cointelegraph" target="_blank" rel="noopener">Cointelegraph Documentaries</a> (2018-ongoing)</li>
+            <li><a href="http://www.deepwebthemovie.com" title="Deep Web" target="_blank" rel="noopener">Deep Web</a> (2015)</li>
+            <li><a href="https://www.dirtycointhemovie.com/" title="Dirty Coin" target="_blank" rel="noopener">Dirty Coin</a> (mining documentaries, 2022-ongoing)</li>
+            <li><a href="https://www.youtube.com/watch?v=H-Yk7aDpdRs" title="Evolution" target="_blank" rel="noopener">Evolution of Bitcoin</a> (2017)</li>
+            <li><a href="https://www.whatbitcoindid.com/wbd-films" title="Follow the Money" target="_blank" rel="noopener">Follow the Money</a> (2022-ongoing)</li>
+            <li><a href="https://www.hardmoneyfilm.com/" title="Hard Money" target="_blank" rel="noopener">Hard Money</a> (2020)</li>
+            <li><a href="https://www.joincolossus.com/episodes/39800754/lowin-hash-power-part-1" title="Hash Power" target="_blank" rel="noopener">Hash Power</a> (2017)</li>
+            <li><a href="https://youtu.be/ZKwqNgG-Sv4" title="How Bitcoin works &amp; why it has value" target="_blank" rel="noopener">How Bitcoin works &amp; why it has value</a> (the history of Bitcoin &amp; money, )</li>
+            <li><a href="https://vimeo.com/658711759?s=08" title="Human B" target="_blank" rel="noopener">Human B</a>(German w/English subtitles, 2021)</li>
+            <li><a href="https://www.youtube.com/watch?v=_0axyH2X6mI" title="Inside Man" target="_blank" rel="noopener">Inside Man</a> (Morgan Spurlock, 2015)</li>
+            <li><a href="https://www.youtube.com/watch?v=K8kua5B5K3I" title="Secret Chinese Mine" target="_blank" rel="noopener">Life Inside a Secret Chinese Bitcoin Mine</a> (2015)</li>
+            <li><a href="https://www.amazon.com/Life-Bitcoin-Austin-M-Craig/dp/B073RQ64FN" title="Life on Bitcoin" target="_blank" rel="noopener">Life on Bitcoin</a> (2017)</li>
+            <li><a href="https://www.youtube.com/watch?v=PVo5wCSnmSs" title="Magic Money" target="_blank" rel="noopener">Magic Money: The Bitcoin Revolution</a> (2018)</li>
+            <li><a href="https://vimeo.com/112223859" title="Bitcoin Doco" target="_blank" rel="noopener">The Bitcoin Doco 1</a> <a href="https://vimeo.com/137032828" title="Bitcoin Doco" target="_blank" rel="noopener"> &amp; 2</a> (2014 & 2015)</li>
+            <li><a href="https://www.amazon.com/Bitcoin-Experiment-Pal-Karleson/dp/B01JBA8HYK/" title="Bitcoin Experiment" target="_blank" rel="noopener">The Bitcoin Experiment</a> (2015)</li>
+            <li><a href="https://www.youtube.com/watch?v=8zKuoqZLyKg" title="Bitcoin Gospel" target="_blank" rel="noopener">The Bitcoin Gospel</a> (2015)</li>
+            <li><a href="https://www.youtube.com/watch?v=6pWblf8COH4" title="Bitcoin Phenomenon" target="_blank" rel="noopener">The Bitcoin Phenomenon</a> (2014)</li>
+            <li><a href="https://www.amazon.com/Bitcoin-Story-Gavin-Andresen/dp/B00V0RZZEI/" title="Bitcoin Story" target="_blank" rel="noopener">The Bitcoin Story</a> (2014)</li>
+            <li><a href="https://blockchain-documentary.com/" title="Blockchain and Us" target="_blank" rel="noopener">The Blockchain and Us</a> (2017)</li>
+            <li><a href="http://bitcoindoc.com/" title="Rise and Rise" target="_blank" rel="noopener">The Rise and Rise of Bitcoin</a> (2014)</li>
+            <li><a href="https://www.rt.com/shows/to-the-moon/" title="To the Moon" target="_blank" rel="noopener">To the Moon (2019)</a></li>
+            <li><a href="https://www.amazon.com/gp/video/detail/B07Y15C7G2/" title="Trust Machine" target="_blank" rel="noopener">Trust Machine - The Story of Blockchain</a> (2018)</li>
+            <li><a href="https://www.youtube.com/watch?v=yQGQXy0RIIo" title="Ulterior States" target="_blank" rel="noopener">Ulterior States</a> (2015)</li>
           </ul>
         </div>
         <!-- RIGHT COLUMN -->


### PR DESCRIPTION
I added the year of the respective documentaries, from the information available in the video metadata. Some links were broken and needed replacing.

PS: if the diff looks jumbled, it's because I renamed "[The Trust Machine](https://youtu.be/ZKwqNgG-Sv4) (the history of Bitcoin & money)" to "How Bitcoin works &amp; why it has value" and moved it up alphabetically to where it belonged. The URL is still the same, just the title changed.