### PR TITLE
Fixing & Updated Mash on lightning-information.html

### DIFF
--- a/lightning-information.html
+++ b/lightning-information.html
@@ -164,6 +164,7 @@
             <li><a href="https://github.com/cdecker/lightning-integration" title="Integration Testing Framework" target="_blank" rel="noopener">Integration Testing Framework</a></li>
             <li><a href="https://github.com/rustyrussell/lnprototest" title="Protocol Test Suite" target="_blank" rel="noopener">Protocol Test Suite</a></li>
             <li><a href="http://www.lightningj.org/" title="Java LND Client" target="_blank" rel="noopener">Java LND client</a></li>
+            <li><a href="guides.mash.com/sdk/" title="Mash Lightning Client SDK" target="_blank" rel="noopener">Mash Lightning Client SDK</a></li>
             <li><a href="https://lndecode.com/" title="Payment Request Decoder" target="_blank" rel="noopener">Payment Request Decoder</a></li>
             <li><a href="https://lightningdecoder.com/" title="Payment Request Decoder" target="_blank" rel="noopener">Payment Request Decoder 2</a></li>
             <li><a href="https://www.npmjs.com/package/bitcoin-lightning-nodejs" title="NodeJS gRPC Library" target="_blank" rel="noopener">NodeJS LND gRPC library</a></li>
@@ -253,6 +254,7 @@
           <h2 id="desktop_wallets"><a href="#desktop_wallets">Desktop Wallets:</a></h2>
           <ul>
             <li><a href="https://zbd.gg/extensions" title="ZBD" target="_blank" rel="noopener">ZBD</a> (browser extension)</li>
+            <li><a href="https://mash.com/consumer-experience/" title="Mash Wallet" target="_blank" rel="noopener">Mash Wallet</a> (web-wallet and pwa)</li>
             <li><a href="https://getalby.com/" title="Alby" target="_blank" rel="noopener">Alby</a> (browser extension)</li>
             <li><a href="https://lightningnetworkstores.com/wallets" title="List of Lightning Wallets" target="_blank" rel="noopener">Comprehensive Wallet List</a></li>
             <li><a href="https://coinos.io/login" title="CoinOS" target="_blank" rel="noopener">CoinOS</a> (Web wallet)</li>
@@ -289,7 +291,7 @@
             <li><a href="https://bottlepay.com/" title="Bottlepay" target="_blank" rel="noopener">Bottlepay</a></li>
             <li><a href="https://www.exodus.com/" title="Exodus" target="_blank" rel="noopener">Exodus</a></li>
             <li><a href="https://galoy.io/bitcoin-beach-wallet/" title="Galoy" target="_blank" rel="noopener">Galoy</a></li>
-            <li><a href="https://app.mash.com/wallet/sign-in" title="Mash" target="_blank" rel="noopener">Mash</a></li>
+            <li><a href="https://mash.com/consumer-experience/" title="Mash" target="_blank" rel="noopener">Mash</a></li>
             <li><a href="https://getspendl.com/" title="Spendl" target="_blank" rel="noopener">Spendl</a> (Bitcoin debit card)</li>
             <li><a href="https://strike.me/en/" title="Strike.me" target="_blank" rel="noopener">Strike.me</a> (Android &amp; iOS &amp; Chrome)</li>
             <li><a href="https://walletofsatoshi.com/" title="Wallet of Satoshi" target="_blank" rel="noopener">Wallet of Satoshi</a></li>
@@ -527,7 +529,7 @@
             <li><a href="https://github.com/ksedgwic/lightning-pos" title="Lightning Pay Station" target="_blank" rel="noopener">Lightning Pay Station</a> (PoS hardware)</li>
             <li><a href="https://lnpay.co/" title="LNPay" target="_blank" rel="noopener">LNPay</a> (payment processor)</li>
             <li><a href="https://github.com/arcbtc/M5StackSats" title="M5StackSats" target="_blank" rel="noopener">M5StackSats</a> (PoS hardware)</li>
-            <li><a href="https://getmash.com/" title="Mash" target="_blank" rel="noopener">Mash</a> – monetize tools</li>
+            <li><a href="https://mash.com/" title="Mash" target="_blank" rel="noopener">Mash</a> – monetize tools</li>
             <li><a href="https://github.com/ElementsProject/nanopos" title="Nano PoS" target="_blank" rel="noopener">Nano PoS</a> (for Lightning Charge)</li>
             <li><a href="https://neutronpay.com/" title="Neutronpay" target="_blank" rel="noopener">Neutronpay</a> (payment processor)</li>
             <li><a href="https://nodeless.io/" title="Nodeless" target="_blank" rel="noopener">Nodeless</a> (payment processor)</li>


### PR DESCRIPTION
Updating mash links from getmash.com to mash.com

Updating mash links to the wallet page vs. app page so that information can be gleaned before asking a user to get started

Added Mash wallet launched a month or so back to the desktop section (PWA).