### PR TITLE
Removed BTCLexicon link (will be replaced with public API)

### DIFF
--- a/bitcoin-information/getting-started.html
+++ b/bitcoin-information/getting-started.html
@@ -103,7 +103,6 @@
           <ul>
             <li><a href="https://bitcoin.org/en/you-need-to-know" title="Basic Facts" target="_blank" rel="noopener">Basic Facts You Need to Know</a></li>
             <li><a href="https://en.bitcoin.it/wiki/Help:FAQ" title="FAQ" target="_blank" rel="noopener">Frequently Asked Questions</a></li>
-            <li><a href="https://btclexicon.com" title="Bitcoin Glossary" target="_blank" rel="noopener">Terms &amp; Definitions - BTCLexicon.com</a></li>
             <li><a href="recommended-wallets.html" title="Wallets">Choose a Wallet</a></li>
             <li><a href="security.html" title="Security">Secure Your Wallet</a></li>
             <li><a href="buying-earning.html" title="Buying">Acquire BTC</a></li>


### PR DESCRIPTION
The BTCLexicon.com website is being replaced with a full-featured public REST API (launching soon). Removing this reference to prevent a temporary dead link.