### PR TITLE
Update buying-earning.html

### DIFF
--- a/bitcoin-information/buying-earning.html
+++ b/bitcoin-information/buying-earning.html
@@ -184,6 +184,8 @@
             <li><a href="https://river.com/" title="River Financial" target="_blank" rel="noopener">River Financial</a> (US)</li>
             <li><a href="https://www.swanbitcoin.com/" title="Swan" target="_blank" rel="noopener">Swan</a> (US)</li>
             <li><a href="https://support.uphold.com/hc/en-us/articles/360046337091-AutoPilot-Automated-Transactions" title="Uphold" target="_blank" rel="noopener">Uphold</a></li>
+            <li><a href="https://sazmining.com" title="Uphold" target="_blank" rel="noopener">Sazmining</a></li>
+
           </ul>
           <h2 id="satsback"><a href="#satsback">"Sats Back" Programs:</a></h2>
           <ul>


### PR DESCRIPTION
Hi Jameson. I added Sazmining under DCA because I wasn't sure where it could fit. We offer Bitcoin Mining as a Service. Meaning, users buy their rigs, and we set everything up so that they receive a part of what the rig produce to their own wallet.