### PR TITLE
Add bitcoinutils.dev script debugger to development tools

### DIFF
--- a/bitcoin-information/developer-tools.html
+++ b/bitcoin-information/developer-tools.html
@@ -169,6 +169,7 @@
             <li><a href="https://siminchen.github.io/bitcoinIDE/build/editor.html" title="Script IDE" target="_blank" rel="noopener">Bitcoin Script IDE</a></li>
             <li><a href="https://paulkernfeld.com/bse/" title="Script Explorer" target="_blank" rel="noopener">Bitcoin Script Explorer</a></li>
             <li><a href="https://github.com/liuhongchao/bitcoin4s" title="bitcoin4s" target="_blank" rel="noopener">bitcoin4s script debugger</a></li>
+            <li><a href="https://bitcoinutils.dev/script/debugger" title="bitcoinutils.dev" target="_blank" rel="noopener">bitcoinutils.dev script debugger</a></li>
             <li><a href="https://github.com/dgpv/bsst" title="symbolic tracer" target="_blank" rel="noopener">Bitcoin Script Symbolic Tracer</a></li>
             <li><a href="https://www.bitscript.app/" title="BitScript" target="_blank" rel="noopener">BitScript</a> (deep dives & debugger)</li>
             <li><a href="https://github.com/kallewoof/btcdeb" title="Script Debugger" target="_blank" rel="noopener">btcdeb Script Debugger</a></li>


### PR DESCRIPTION
A few weeks ago I released the [bitcoinutils.dev script debugger](https://bitcoinutils.dev/script/debugger) and I'd like to have it added to the development tools page. Most web-based script debuggers I've tried in the past (including those listed on the page) either don't have all opcodes or have serious bugs, which prompted me to implement one myself.