### PR TITLE
Update news.html

### DIFF
--- a/bitcoin-information/news.html
+++ b/bitcoin-information/news.html
@@ -107,7 +107,6 @@
             <li><a href="https://bitcoinops.org/en/newsletters/" title="Bitcoin Optech" target="_blank" rel="noopener">Bitcoin Optech Newsletter</a></li>
             <li><a href="https://www.btctimes.com/" title="BTC Times" target="_blank" rel="noopener">BTC Times</a></li>
             <li><a href="http://www.coindesk.com/" title="Coindesk" target="_blank" rel="noopener">Coindesk</a></li>
-            <li><a href="http://coinjournal.net/" title="CoinJournal" target="_blank" rel="noopener">CoinJournal</a></li>
             <li><a href="https://finbold.com/" title="Finbold" target="_blank" rel="noopener">Finbold</a></li>
             <li><a href="https://messari.io/" title="Messari" target="_blank" rel="noopener">Messari</a></li>
             <li><a href="https://www.nobsbitcoin.com/" title="No BS Bitcoin" target="_blank" rel="noopener">No BS Bitcoin</a></li>


### PR DESCRIPTION
I used to write for CoinJournal back in the day, but it was sold some years ago and appears to be mostly altcoin blog spam now. I suggest removing it.