### PR TITLE
Add Dumplings

### DIFF
--- a/bitcoin-information/statistics-metrics.html
+++ b/bitcoin-information/statistics-metrics.html
@@ -104,6 +104,7 @@
             <li><a href="https://dashboard.bitcoinops.org" title="Optech Dashboard" target="_blank" rel="noopener">Bitcoin Optech Dashboards</a></li>
             <li><a href="https://bitinfocharts.com/top-100-richest-bitcoin-addresses.html" title="Richest Addresses" target="_blank" rel="noopener">Bitcoin Richlist</a></li>
             <li><a href="https://data.bitcoinity.org/markets/volume/30d?c=e&t=b" title="Bitcoinity" target="_blank" rel="noopener">Bitcoinity</a> - Exchange &amp; Blockchain stats</li>
+            <li><a href="https://github.com/nopara73/Dumplings/" title="Dumplings" target="_blank" rel="noopener">Dumplings</a> - Coinjoin stats</li>
             <li><a href="http://opreturn.org/" title="OP_RETURN" target="_blank" rel="noopener">OP_RETURN Stats</a></li>
             <li><a href="https://transactionfee.info/charts/" title="Payment Stats" target="_blank" rel="noopener">Payment Stats</a></li>
             <li><a href="https://bitcoin-supply.com/" title="Lost Bitcoin" target="_blank" rel="noopener">Provably Lost Bitcoin</a></li>


### PR DESCRIPTION
Dumplings are the most extensive coinjoin statistic tool, it used to power https://stats.wasabiwallet.io/ which stopped updating after sunsetting zkSNACKs.