### PR TITLE
remove link 'LN Timeline'

### DIFF
--- a/lightning-information.html
+++ b/lightning-information.html
@@ -109,7 +109,6 @@
           <h2 id="history"><a href="#history">History:</a></h2>
           <ul>
             <li><a href="https://bitcoinmagazine.com/articles/history-lightning-brainstorm-beta/" title="Early History" target="_blank" rel="noopener">Early History</a></li>
-            <li><a href="https://gcomte.github.io/lightning-timeline" title="Historical Timeline of Developments" target="_blank" rel="noopener">LN Timeline</a></li>
             <li><a href="https://www.youtube.com/watch?v=HauP9F16mUM" title="Historical Video Presentation" target="_blank" rel="noopener">History of LN</a> (Christian Decker)</li>
             <li><a href="https://bitcoinmagazine.com/technical/lightning-torchs-bitcoin-payment-is-running-a-worldwide-marathon" title="History of Lightning Torch" target="_blank" rel="noopener">History of Lightning Torch</a></li>
             <li><a href="https://www.mail-archive.com/lightning-dev@lists.linuxfoundation.org/" title="Lightning Dev Mailing List" target="_blank" rel="noopener">Developer Mailing List Archive</a></li>


### PR DESCRIPTION
I'm the author of the project and I'm about to archive it. It hasn't been updated in 6 years.

If anyone else wants to maintain it, feel free to do so! It's all open source.