### PR TITLE
add new BTC wallet for TOR

### DIFF
--- a/bitcoin-information/recommended-wallets.html
+++ b/bitcoin-information/recommended-wallets.html
@@ -124,6 +124,7 @@
             <li>Extreme Privacy: <a href="https://github.com/JoinMarket-Org/joinmarket-clientserver" title="Joinmarket" target="_blank" rel="noopener">Joinmarket</a></li>
             <li>Extreme Security: <a href="https://casa.io/" title="Casa" target="_blank" rel="noopener">Casa</a></li>
             <li>Insured: <a href="https://www.anchorwatch.com/" title="AnchorWatch" target="_blank" rel="noopener">AnchorWatch</a></li>
+            <li>Tor-Ready: <a href="https://coin.space/" title="Coin Wallet" target="_blank" rel="noopener">Coin Wallet</a></li>
           </ul>
           <h2 id="backups"><a href="#backups">Wallet Backups:</a></h2>
           <ul>


### PR DESCRIPTION
Hey! Seems like all platform categories are already taken - except for Tor. Mind checking out our wallet? It's self-custodial, live since 2015. Most users are on web but you have BitGo (custodial?).
Tor keeps gaining traction, and our wallet works right in the browser. No install needed. Could be a great fit under “Tor-ready”.