### PR TITLE
Add link to Miniscript Studio

### DIFF
--- a/bitcoin-information/technical-resources.html
+++ b/bitcoin-information/technical-resources.html
@@ -160,6 +160,7 @@
             <li><a href="https://github.com/rust-bitcoin/rust-miniscript" title="rust" target="_blank" rel="noopener">Rust Library</a></li>
             <li><a href="https://www.youtube.com/watch?v=_v1lECxNDiM" title="Poelstra" target="_blank" rel="noopener">Andrew Poelstra Presentation</a></li>
             <li><a href="https://www.youtube.com/watch?v=sQOfnsW6PTY&t=22541s" title="Pieter Wuille" target="_blank" rel="noopener">Peter Wuille Presentation</a></li>
+            <li><a href="https://adys.dev/miniscript/" title="Miniscript Studio" target="_blank" rel="noopener">Miniscript Studio</a></li>            
           </ul>
         </div>
         <!-- RIGHT COLUMN -->


### PR DESCRIPTION
Add a Miniscript Studio link (https://adys.dev/miniscript) to technical-resources.html under Miniscript resources 