### PR TITLE
Add Manna wallet link to lightning information page

### DIFF
--- a/lightning-information.html
+++ b/lightning-information.html
@@ -278,6 +278,7 @@
             <li><a href="https://blixtwallet.github.io" title="Blixt Wallet" target="_blank" rel="noopener">Blixt Wallet</a> (Android &amp; iOS)</li>
             <li><a href="https://github.com/breez/breezmobile" title="Breez" target="_blank" rel="noopener">Breez</a> (Android &amp; iOS)</li>
             <li><a href="https://lastbit.io/" title="Lastbit" target="_blank" rel="noopener">Lastbit</a></li>
+            <li><a href="https://mannabitcoin.com" title="Manna" target="_blank" rel="noopener">Manna</a> (Android &amp; iOS)</li>
             <li><a href="https://muun.com/" title="Muun" target="_blank" rel="noopener">Muun</a> (Android &amp; iOS)</li>
             <li><a href="https://phoenix.acinq.co" title="Phoenix" target="_blank" rel="noopener">Phoenix</a> (Android)</li>
             <li><a href="https://beta.strike.me/download" title="Strike.me" target="_blank" rel="noopener">Strike.me</a> (Android &amp; iOS &amp; Chrome)</li>


### PR DESCRIPTION
Addition to the Lightning Mobile Wallets section.