### PR TITLE
Add Lightning Faucet to Earning Bitcoins section

### DIFF
--- a/bitcoin-information/buying-earning.html
+++ b/bitcoin-information/buying-earning.html
@@ -157,6 +157,7 @@
             <li><a href="/bitcoin-information/careers" title="Careers" target="_blank" rel="noopener">Careers</a></li>
             <li><a href="https://fountain.fm/" title="Fountain" target="_blank" rel="noopener">Fountain</a> (listen to podcasts)</li>
             <li><a href="https://www.reddit.com/r/Jobs4Bitcoins/" title="Jobs" target="_blank" rel="noopener">Job Postings</a></li>
+            <li><a href="https://lightningfaucet.com/" title="Lightning Faucet" target="_blank" rel="noopener">Lightning Faucet</a> (earn sats via Lightning)</li>
             <li><a href="https://addslice.com/" title="Slice" target="_blank" rel="noopener">Slice</a></li>
           </ul>
           <h2 id="escrow"><a href="#escrow">Escrow Services:</a></h2>


### PR DESCRIPTION
Adding **Lightning Faucet** to the Earning Bitcoins section.

**Entry:**
```html
<li><a href="https://lightningfaucet.com/" title="Lightning Faucet" target="_blank" rel="noopener">Lightning Faucet</a> (earn sats via Lightning)</li>
```

**What it is:**
- Bitcoin rewards platform where users earn sats through Lightning Network
- Provably fair using HMAC-SHA256 cryptographic verification
- LNURL-auth login, instant Lightning withdrawals
- Also features AI Agent Wallet for developers building autonomous agents

**Website:** https://lightningfaucet.com

Thanks for maintaining this incredible resource!