### PR TITLE
Add bitcoinbottom.app to Bitcoin Statistics & Metrics

### DIFF
--- a/bitcoin-information/statistics-metrics.html
+++ b/bitcoin-information/statistics-metrics.html
@@ -139,6 +139,7 @@
           <ul>
             <li><a href="https://asicboost.dance/" title="ASICBoost" target="_blank" rel="noopener">AsicBoost Stats</a></li>
             <li><a href="https://bitbo.io/" title="Bitbo Dashboard" target="_blank" rel="noopener">Bitbo Dashboard</a></li>
+            <li><a href="https://bitcoinbottom.app" title="Bitcoin Bottom Score" target="_blank" rel="noopener">Bitcoin Bottom Score</a> - on-chain market cycle bottom probability tracker (25 signals)</li>
             <li><a href="https://github.com/bitcoin-data" title="Bitcoin Data" target="_blank" rel="noopener">Bitcoin Data</a> (collection of data sets)</li>
             <li><a href="https://bitcoinisdata.info/" title="Bitcoin is Data" target="_blank" rel="noopener">Bitcoin is Data</a></li>
             <li><a href="https://coin.dance/stats" title="Demographics" target="_blank" rel="noopener">Bitcoin demographics &amp; misc stats</a></li>


### PR DESCRIPTION
## What

Adds [bitcoinbottom.app](https://bitcoinbottom.app) to the Miscellaneous Metrics section.

## Description

Bitcoin Bottom Score is a free, no-signup on-chain market cycle bottom probability tracker. It aggregates 25 on-chain signals — MVRV Z-Score, Puell Multiple, Hash Ribbon, Fear & Greed Index, Realized Price, NVT Ratio, Funding Rates, Coinbase Premium, STH/LTH SOPR, and more — into a single daily score. Currently sits alongside tools like Glassnode Studio and Check On Chain in the analytics space.