### PR TITLE
Add crypto wallet security checklist to security guides

### DIFF
--- a/bitcoin-information/security.html
+++ b/bitcoin-information/security.html
@@ -123,6 +123,7 @@
             <li><a href="https://cryptoconsortium.github.io/CCSS/" title="Cryptocurrency Security Standard" target="_blank" rel="noopener">Cryptocurrency Security Standard</a> (for enterprises)</li>
             <li><a href="https://blog.casa.io/the-dos-and-donts-of-bitcoin-key-management/" title="The Dos and Donts of Key Management" target="_blank" rel="noopener">The Dos and Don'ts of Key Management</a></li>
             <li><a href="https://bitcoin.org/en/secure-your-wallet" title="Wallet Security" target="_blank" rel="noopener">Securing Your Wallet</a></li>
+            <li><a href="https://snout0x.com/crypto-wallet-security-checklist/" title="Crypto Wallet Security Checklist" target="_blank" rel="noopener">Crypto Wallet Security Checklist</a> - practical self-custody checklist covering seed handling, device trust, approvals, and transaction hygiene.</li>
             <li><a href="https://github.com/BlockchainCommons/SmartCustodyBook" title="Smart Custody" target="_blank" rel="noopener">Smart Custody Book</a></li>
           </ul>
           <h2 id="checks"><a href="#checks">Security Checks:</a></h2>


### PR DESCRIPTION
Added one plain-language self-custody security resource to the Bitcoin Security Guides section.

Why this one:
- practical checklist format
- focused on seed handling, device trust, approvals, and transaction hygiene
- educational resource, not a product/review page