### PR TITLE
Add Self-Custody Score to Security Checks

### DIFF
--- a/bitcoin-information/security.html
+++ b/bitcoin-information/security.html
@@ -131,6 +131,7 @@
             <li><a href="https://jlopp.github.io/bitcoin-confirmation-risk-calculator/" target="_blank" rel="noopener">Bitcoin Confirmation Risk Calculator</a></li>
             <li><a href="https://binarywatch.org/" title="Binary Watch" target="_blank" rel="noopener">Binary Watch</a></li>
             <li><a href="https://walletscrutiny.com/" title="Wallet Scrutiny" target="_blank" rel="noopener">Wallet Scrutiny</a></li>
+            <li><a href="https://dont-trust-verify.com/tools/self-custody-score" title="Self-Custody Score" target="_blank" rel="noopener">Self-Custody Score</a> (8-question self-custody audit)</li>
          </ul>
           <h2 id="backups"><a href="#backups">Wallet Backups:</a></h2>
           <ul>


### PR DESCRIPTION
Adding [Self-Custody Score](https://dont-trust-verify.com/tools/self-custody-score) to the Security Checks section — a free 8-question audit that grades how someone actually stores their Bitcoin (A+ to F), shows their weakest area (storage / backups / verify-before-sign / passphrase / inheritance / install integrity), and recommends the single highest-leverage fix.

Runs entirely client-side in the browser — no signup, no tracking, nothing leaves the device. Happy to adjust the entry or section if you prefer.