### PR TITLE
Add BTCDash to statistics-metrics

### DIFF
--- a/bitcoin-information/statistics-metrics.html
+++ b/bitcoin-information/statistics-metrics.html
@@ -210,4 +210,3 @@
   <script src="../js/combined.js"></script>
 </body>
 </html>
-Page_UpPage_Up

--- a/bitcoin-information/statistics-metrics.html
+++ b/bitcoin-information/statistics-metrics.html
@@ -148,6 +148,7 @@
             <li><a href="https://bitview.space/" title="Bitview Space" target="_blank" rel="noopener">Bitview Space </a>(Glassnode &amp; mempool.space mashup)</li>
             <li><a href="https://bitcoin-data.github.io/block-arrival-times/" title="Block Arrival Times" target="_blank" rel="noopener">Block Arrival Times</a></li>
             <li><a href="https://blockchain.info/charts" title="Blockchain Charts" target="_blank" rel="noopener">Blockchain Charts</a></li>
+            <li><a href="https://btcdash.org/" title="BTCDash" target="_blank" rel="noopener">BTCDash</a> - Free real-time dashboard: price, fees, halving, sentiment &amp; on-chain metrics</li>
             <li><a href="https://casasciustracker.com/" title="Casascius Coin Tracker" target="_blank" rel="noopener">Casascius Coin Tracker</a></li>
             <li><a href="https://wickedsmartbitcoin.com/casascius_explorer" title="Casascius Explorer" target="_blank" rel="noopener">Casascius Explorer</a> (Wicked Smart Bitcoin)</li>
             <li><a href="https://charts.checkonchain.com/" title="checkonchain" target="_blank" rel="noopener">Check On Chain</a></li>
@@ -209,3 +210,4 @@
   <script src="../js/combined.js"></script>
 </body>
 </html>
+Page_UpPage_Up


### PR DESCRIPTION
Adds BTCDash (btcdash.org) to Miscellaneous Metrics, alphabetically between Blockchain Charts and Casascius Coin Tracker. It's a free real-time Bitcoin dashboard: price with long-term moving averages, fee market, halving countdown, Fear & Greed, on-chain metrics (MVRV, NUPL, realized price), Lightning stats and miner economics — ~70 live cards, fully client-side from public APIs (mempool.space, Coin Metrics, exchanges). No signup, no ads, no affiliate/referral links. Disclosure: I'm the author.