### PR TITLE
Update BitcoinMythBusters link in getting started guide

### DIFF
--- a/bitcoin-information/getting-started.html
+++ b/bitcoin-information/getting-started.html
@@ -144,7 +144,7 @@
           <h2 id="misconceptions"><a href="#misconceptions">Misconceptions:</a></h2>
           <ul>
             <li><a href="/pdf/Fidelity_Digital_Assets-Revisiting_Persistent_Bitcoin_Criticisms.pdf" title="Addressing Persistent Criticisms" target="_blank" rel="noopener">Addressing Persistent Criticisms</a></li>
-            <li><a href="https://bitcoinmythbusters.org/" title="BitcoinMythBusters" target="_blank" rel="noopener">Copy &amp; paste rebuttals to common critiques</a></li>
+            <li><a href="https://rene78.github.io/BitcoinMythBusters/" title="BitcoinMythBusters" target="_blank" rel="noopener">Copy &amp; paste rebuttals to common critiques</a></li>
             <li><a href="https://web.archive.org/web/20250324164852/https://safehodl.github.io/failure/" title="Every Reason Bitcoin Will Not Fail" target="_blank" rel="noopener">Every Reason Bitcoin Will Not Fail</a></li>
             <li><a href="https://endthefud.org/" title="End the FUD" target="_blank" rel="noopener">FUD Debunking Articles</a></li>
             <li><a href="https://www.youtube.com/watch?v=8aLwhLNgrsM&list=PLADkFLG_TN5F_OPqrjTceXNm-q6UsttjZ" title="FUD series" target="_blank" rel="noopener">FUD Debunking Videos</a></li>


### PR DESCRIPTION
I didn't renew the domain name. Thus link replaced to the generic Github Pages domain.