### PR TITLE
Add The Bitcoin Act to Legal News

### DIFF
--- a/bitcoin-information/legal.html
+++ b/bitcoin-information/legal.html
@@ -101,6 +101,7 @@
         <div class="text-left col-xs-12 col-sm-6 col-lg-6 col-md-6">
           <h2 id="legal"><a href="#legal">Legal News:</a></h2>
           <ul>
+            <li><a href="https://thebitcoinact.xyz" title="Bitcoin Act" target="_blank" rel="noopener">The Bitcoin Act</a></li>
             <li><a href="https://theblockchainmonitor.com" title="Blockchain Monitor" target="_blank" rel="noopener">The Blockchain Monitor</a></li>
             <li><a href="https://coincenter.org/" title="Coin Center" target="_blank" rel="noopener">Coin Center</a></li>
             <li><a href="https://www.mishcon.com/crypto" title="Legal Cases" target="_blank" rel="noopener">Cryptocurrency Case Tracker</a></li>


### PR DESCRIPTION
Adds The Bitcoin Act to the Legal News section.

https://thebitcoinact.xyz

A twice-weekly newsletter, covering Bitcoin regulation, tax, self-custody and inheritance across the US and worldwide. Bitcoin only, no altcoin coverage.

The Legal News section currently has no recurring publication in it, so this fills a gap rather than duplicating an existing resource.