### PR TITLE
Add nodsig to Blockchain Querying

### DIFF
--- a/bitcoin-information/developer-tools.html
+++ b/bitcoin-information/developer-tools.html
@@ -113,6 +113,7 @@
             <li><a href="https://chainquery.com" title="Bitcoin RPC API in your browser" target="_blank" rel="noopener">Bitcoin RPC API in your browser</a></li>
             <li><a href="https://github.com/emeraldpay/dshackle-archive" title="Dshackle Archive" target="_blank" rel="noopener">Dshackle Archive</a> blockchain ETL</li>
             <li><a href="https://github.com/ZuInnoTe/hadoopcryptoledger" title="Hadoop" target="_blank" rel="noopener">Hadoop Crypto Ledger</a></li>
+            <li><a href="https://github.com/amenano/nodsig" title="nodsig" target="_blank" rel="noopener">nodsig</a> sealed artifacts for offline chain queries</li>
             <li><a href="https://github.com/s0md3v/Orbit" title="Orbit" target="_blank" rel="noopener">Orbit</a> Cluster Analysis</li>
             <li><a href="https://github.com/dpc/rust-bitcoin-indexer" title="Indexer" target="_blank" rel="noopener">Rust Bitcoin Indexer</a></li>
             <li><a href="https://github.com/ladimolnar/BitcoinDatabaseGenerator" title="Database Generator" target="_blank" rel="noopener">Database Generator</a></li>


### PR DESCRIPTION
One entry for nodsig in the Blockchain Querying section: a Python stdlib-only tool that builds sealed artifacts from your own node's blocks, so chain questions (first spend, key exposure, per-block stats) become offline file lookups, and every answer carries a fingerprint anyone can recompute.
Compared to the parsers and indexers already listed: no database and no dependencies to install, the output is a set of verifiable flat files. MIT, documented, 379 tests.