### PR TITLE
Add EIDEX swap route comparison to Buying Bitcoins

### DIFF
--- a/bitcoin-information/buying-earning.html
+++ b/bitcoin-information/buying-earning.html
@@ -111,6 +111,7 @@
             <li><a href="https://cointastical.medium.com/bitcoin-crypto-otc-trading-desks-7f77276c6dc" title="OTC" target="_blank" rel="noopener">OTC Trading Desks</a></li>
             <li><a href="https://docs.google.com/spreadsheets/d/1_w-vs7dd23esXFqyH0ZW7mbYThD3nStKFoaN8Vu3pfk/edit#gid=93266521" title="Exchange Fee Comparison" target="_blank" rel="noopener">Exchange Fee Comparison</a></li>
             <li><a href="https://biscoint.io/bitcoin/price-comparison/buy/single-exchange" title="Exchange Price Comparison" target="_blank" rel="noopener">Realtime Exchange Price Comparison</a></li>
+            <li><a href="https://eidex.io/screener/btc-btc-to-usdt-erc20" title="EIDEX" target="_blank" rel="noopener">Realtime Swap Quote Comparison</a></li>
             <li><a href="https://www.sbb.ch/en/station-services/at-the-station/services-from-the-ticket-machine/bitcoin.html" title="SBB" target="_blank" rel="noopener">Swiss Railway Ticketing</a></li>
             <li><a href="https://unbank.com/" title="Unbank" target="_blank" rel="noopener">Unbank</a> (ATMs &amp; Retail Stores)</li>
           </ul>


### PR DESCRIPTION
adds Eidex next to the other price comparison links. It compares live btc swap quotes from 13+ providers (chainflip, thorchain, ff, stealthex and others) on one page, no account needed. non-custodial, the page only shows the routes and links out to the providers.