### PR TITLE
privacy: drop hijacked coinjoins.org, add Privacy on Bitcoin chapter

### DIFF
--- a/bitcoin-information/privacy.html
+++ b/bitcoin-information/privacy.html
@@ -110,6 +110,7 @@
             <li><a href="https://enegnei.github.io/This-Month-In-Bitcoin-Privacy/" title="This Month" target="_blank" rel="noopener">This Month in Bitcoin Privacy</a></li>
             <li><a href="https://bitcoin.org/en/protect-your-privacy" title="Privacy Guide" target="_blank" rel="noopener">Bitcoin.org's Privacy Guide</a></li>
             <li><a href="https://medium.com/human-rights-foundation-hrf/privacy-and-cryptocurrency-part-i-how-private-is-bitcoin-e3a4071f8fff" title="Privacy Primer" target="_blank" rel="noopener">Bitcoin Privacy Primer</a></li>
+            <li><a href="https://www.learnbitcoin.com/rabbit-hole/bitcoin-privacy" title="Privacy on Bitcoin" target="_blank" rel="noopener">Privacy on Bitcoin: What Works and What Doesn't</a> (how chain analysis traces coins, the 2024 coordinator cases, what still holds)</li>
             <li><a href="https://web.archive.org/web/20200714004203/https://joinmarket.me/blog/blog/tumblebit-for-the-tumble-curious/" title="TumbleBit" target="_blank" rel="noopener">How TumbleBit Works</a></li>
             <li><a href="https://github.com/OpenBitcoinPrivacyProject/wallet-ratings/blob/master/report-02/threat%20model.wiki" title="Open Bitcoin Privacy Project" target="_blank" rel="noopener">Open Bitcoin Privacy Project Threat Model</a></li>
             <li><a href="https://silentpayments.xyz" title="Silent Payments" target="_blank" rel="noopener">Silent Payments</a> (private static addresses)</li>
@@ -120,7 +121,6 @@
           <ul>
             <li><a href="https://ashigaru.rs/" title="Ashigaru" target="_blank" rel="noopener">Ashigaru</a> (CoinJoin)</li>
             <li><a href="https://am-i.exposed/" title="Am I Exposed?" target="_blank" rel="noopener">Am I Exposed?</a> (Chain Analysis Tool)</li>
-            <li><a href="https://www.coinjoins.org/" title="Coinjoins" target="_blank" rel="noopener">Coinjoin Resources</a></li>
             <li><a href="https://coinjoin.nl/index.html" title="Coinjoin.nl" target="_blank" rel="noopener">Coinjoin.nl</a> (WabiSabi Coordinator)</li>
             <li><a href="https://joinmarket-ng.github.io/joinmarket-ng/" title="JoinMarket NG" target="_blank" rel="noopener">JoinMarket NG</a> (CoinJoin)</li>
             <li><a href="https://github.com/BTCtoolshed/MeshtasticBitcoinCore_Bridge" title="Meshtastic" target="_blank" rel="noopener">Meshtastic Bridge</a> (transaction broadcaster)</li>


### PR DESCRIPTION
coinjoins.org now serves a casino affiliate page (see its title tag), so this drops it from Privacy Software.

Also adds LearnBitcoin's "Privacy on Bitcoin: What Works and What Doesn't" to the resources list: how the clustering heuristics work, where the name attaches (the exchange record), the 2024 Samourai/Wasabi cases and what survived, PayJoin and silent payments. Sourced to DOJ releases, the BIPs, the Meiklejohn paper, and the Sterlingov Daubert opinion. LearnBitcoin is already on getting-started.html (#1209); this is the topic-specific piece. I run the site.
